### PR TITLE
Remove unnecessary final variable

### DIFF
--- a/ghostwriter-jdk-v7/src/main/java/io/ghostwriter/openjdk/v7/GhostWriterAnnotationProcessor.java
+++ b/ghostwriter-jdk-v7/src/main/java/io/ghostwriter/openjdk/v7/GhostWriterAnnotationProcessor.java
@@ -50,8 +50,7 @@ public class GhostWriterAnnotationProcessor extends AbstractProcessor {
             }
         }
 
-        final boolean doClaimAnnotations = false;
-        return doClaimAnnotations;
+        return false;
     }
 
 }


### PR DESCRIPTION
Since the variable will always take the false value, there is no reason to keep it. The function always return false. This behaviour is quiestionable, but at least the code clearly represents the actual flow.