### PR TITLE
Fix Gradle build dependency declaration in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "io.ghostwriter:ghostwriter-jdk-v8:{version}"
+    compile "io.ghostwriter:ghostwriter-jdk-v8:{version}"
 }
 ----
 
@@ -117,7 +117,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "io.ghostwriter:ghostwriter-jdk-v7:{version}" // <1>
+    compile "io.ghostwriter:ghostwriter-jdk-v7:{version}" // <1>
 }
 ----
 <1> Note the use of `ghostwriter-jdk-v7`


### PR DESCRIPTION
Why:
 - In the README, it's mentioned that ghostwriter should be added to a Gradle build with
   'compileOnly "io.ghostwriter:ghostwriter-jdk-v8:0.5.0"'. This is not consistent with
   the instructions for Maven where it says one should add ghostwriter with scope
   'compile'.
 - Adding ghostwriter with 'compileOnly' leads to the fact, that ghostwriter
   is not available on the runtime classpath, which in turn leads to failing
   unit tests etc, as an implementation of ghostwriter needs to be on the runtime
   classpath during execution.

How:
 - Changed dependency declaration instructions in README from 'compileOnly' to 'compile'.

What are the effects:
 - ghostwriter is available on the runtime classpath.